### PR TITLE
Be much more efficient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ include = [
 ]
 
 [dependencies]
-regex = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ include = [
 ]
 
 [dependencies]
+
+[dev-dependencies]
+quickcheck = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,411 +1,317 @@
 #![crate_name = "hashids"]
 
-extern crate regex;
-
-use std::collections::HashMap;
-use regex::Regex;
-
 const DEFAULT_ALPHABET: &'static str =  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 const DEFAULT_SEPARATORS: &'static str = "cfhistuCFHISTU";
-const SEPARTOR_DIV: f32 = 3.5;
-const GUARD_DIV: u32 = 12;
+const SEPARATOR_DIV: f32 = 3.5;
+const GUARD_DIV: f32 = 12.0;
 const MIN_ALPHABET_LENGTH: usize = 16;
 
 pub enum HashIdsError { InvalidAlphabetLength }
 
 pub struct HashIds {
-  salt: String,
-  pub alphabet: String,
-  separators: String,
+  salt: Box<str>,
+  alphabet: Box<[char]>,
+  separators: Box<[char]>,
   min_hash_length: usize,
-  guards: String 
+  guards: Box<[char]>,
 }
 
 impl HashIds {
-  pub fn new(salt: String, min_hash_length: usize, alphabet: String) -> Result<HashIds, HashIdsError>  {
-    let min_length = HashIds::get_min_hash_length(min_hash_length);
-    let unique_alphabet = HashIds::get_unique_alphabet(alphabet);
+  pub fn with_min_length_and_alphabet(salt: String, min_length: usize, alphabet: &str) -> Result<HashIds, HashIdsError>
+  {
+    let mut alphabet = {
+      let mut unique_alphabet = Vec::with_capacity(alphabet.len());
+      for ch in alphabet.chars() {
+        if !unique_alphabet.contains(&ch) {
+          unique_alphabet.push(ch);
+        }
+      }
+      unique_alphabet
+    };
 
-    if unique_alphabet.len() < MIN_ALPHABET_LENGTH {
+    if alphabet.len() < MIN_ALPHABET_LENGTH {
       return Err(HashIdsError::InvalidAlphabetLength);
     }
 
-    let (t_separators, mut t_alphabet) = HashIds::get_separators(unique_alphabet);
-    let mut shuffled_separators = HashIds::hashids_shuffle(t_separators.clone(), salt.clone());
+    let mut separators: Vec<char> = DEFAULT_SEPARATORS.chars().collect();
+    for i in (0..separators.len()).rev() {
+      match alphabet.iter().position(|&ch| ch == separators[i]) {
+        Some(idx) => {
+          alphabet.remove(idx);
+        },
+        None => {
+          separators.remove(i);
+        }
+      }
+    }
 
-    if HashIds::need_manipulate(shuffled_separators.len(), t_alphabet.len()) == true {
-      let mut seps_len =  ((t_alphabet.len() as f32) / SEPARTOR_DIV) as usize;
+    HashIds::shuffle(&mut separators, &salt);
+
+
+    if separators.is_empty() || (alphabet.len() as f32 / separators.len() as f32) > SEPARATOR_DIV {
+      let mut seps_len = ((alphabet.len() as f32) / SEPARATOR_DIV).ceil() as usize;
       if seps_len == 1 {
         seps_len += 1;
       }
 
-      if seps_len > shuffled_separators.len() {
-        let diff = seps_len - shuffled_separators.len();
+      if seps_len > separators.len() {
+        let diff = seps_len - separators.len();
 
-        shuffled_separators.push_str(&t_alphabet[..diff]);
-        t_alphabet = t_alphabet[diff..].to_string();
+        separators.extend_from_slice(&alphabet[..diff]);
+        alphabet.drain(..diff);
       } else {
-        shuffled_separators = shuffled_separators[..seps_len].to_string();
+        separators.truncate(seps_len);
       }
     }
 
-    let mut shuffled_alphabet = HashIds::hashids_shuffle(t_alphabet.clone(), salt.clone());
-    let guard_count = (shuffled_alphabet.len() as f32 / GUARD_DIV as f32).ceil() as usize;
+    HashIds::shuffle(&mut alphabet, &salt);
+    let guard_count = (alphabet.len() as f32 / GUARD_DIV).ceil() as usize;
 
-    let t_guards;
+    let guards;
 
-    if shuffled_alphabet.len() < 3 {
-      t_guards = shuffled_separators[..guard_count].to_string();
-      shuffled_separators = shuffled_separators[guard_count..].to_string();
+    if alphabet.len() < 3 {
+      guards = separators[..guard_count].to_vec();
+      separators.drain(..guard_count);
     } else {
-      t_guards = shuffled_alphabet[..guard_count].to_string();
-      shuffled_alphabet = shuffled_alphabet[guard_count..].to_string();
+      guards = alphabet[..guard_count].to_vec();
+      alphabet.drain(..guard_count);
     }
 
     Ok(HashIds {
-      salt: salt,
+      salt: salt.into_boxed_str(),
       min_hash_length: min_length,
-      guards: t_guards,
-      separators: shuffled_separators,
-      alphabet: shuffled_alphabet
+      guards: guards.into_boxed_slice(),
+      separators: separators.into_boxed_slice(),
+      alphabet: alphabet.into_boxed_slice(),
     })
   }
 
-  pub fn new_with_salt_and_min_length(salt: String, min_hash_length: usize) -> Result<HashIds, HashIdsError> {
-    HashIds::new(salt, min_hash_length, DEFAULT_ALPHABET.to_string())
+  pub fn with_min_length(salt: String, min_hash_length: usize) -> Result<HashIds, HashIdsError> {
+    HashIds::with_min_length_and_alphabet(salt, min_hash_length, DEFAULT_ALPHABET)
   }
 
-  pub fn new_with_salt(salt: String) -> Result<HashIds, HashIdsError> {
-    HashIds::new_with_salt_and_min_length(salt, 0)
+  pub fn new(salt: String) -> Result<HashIds, HashIdsError> {
+    HashIds::with_min_length(salt, 0)
   }
 
+  pub fn encode_hex(&self, hex: &str) -> Option<String> {
+    let mut numbers: Vec<u64> = Vec::with_capacity(hex.len() / 12);
+    for chunk in hex.as_bytes().chunks(12) {
+      let mut number = 1;
+      for &ch in chunk {
+        let digit = match ch {
+          b'0'...b'9' => ch - b'0',
+          b'a'...b'f' => ch - b'a' + 10,
+          b'A'...b'F' => ch - b'A' + 10,
+          _ => return None,
+        } as u64;
+        number <<= 4;
+        number |= digit;
+      }
+      numbers.push(number);
+    }
+    Some(self.encode(&numbers))
+  }
 
-  fn need_manipulate(slen: usize, alen: usize) -> bool {
-    if slen <= 0 || (((alen/slen) as f32)> SEPARTOR_DIV) {
-      return true;
+  pub fn decode_hex(&self, hash: &str) -> Option<String> {
+    use std::fmt::Write;
+    match self.decode(hash) {
+      Some(numbers) => {
+        let mut result = String::new();
+        let mut buffer = String::new();
+        for number in numbers {
+          write!(buffer, "{:x}", number).unwrap();
+          result.push_str(&buffer[1..])
+        }
+        Some(result)
+      },
+      None => None,
+    }
+  }
+
+  pub fn decode(&self, hash: &str) -> Option<Vec<u64>> {
+    let mut hash_chars: Vec<char> = hash.chars().collect();
+    if let Some(end_guard) = hash_chars.iter().rposition(|ch| self.guards.contains(ch)) {
+      hash_chars.truncate(end_guard);
+    }
+    if let Some(start_guard) = hash_chars.iter().position(|ch| self.guards.contains(ch)) {
+      hash_chars.drain(..start_guard);
+    }
+    if hash_chars.iter().any(|ch| self.guards.contains(ch)) {
+      // If any guard characters are left, hash is invalid
+      return None;
+    }
+    if hash_chars.is_empty() {
+      return None;
     }
 
-    false
-  }
+    let num_results = hash_chars.iter().filter(|ch| self.separators.contains(ch)).count() + 1;
+    let mut result = Vec::with_capacity(num_results);
 
-  fn get_min_hash_length(length: usize) -> usize {
-    if length > 0 {
-      return length;
-    } else {
-      return 0;
+    let lottery = hash_chars.remove(0);
+    let mut alphabet = self.alphabet.clone();
+    let mut buffer = String::with_capacity(alphabet.len());
+    buffer.push(lottery);
+    buffer.push_str(&self.salt);
+    if buffer.len() > alphabet.len() {
+      buffer.truncate(alphabet.len());
     }
+    let const_buffer_len = buffer.len();
+    for sub_hash in hash_chars.split(|ch| self.separators.contains(ch)) {
+      buffer.truncate(const_buffer_len);
+      if buffer.len() < alphabet.len() {
+        let extra_needed = alphabet.len() - buffer.len();
+        buffer.extend(alphabet[..extra_needed].iter());
+      }
+      HashIds::shuffle(&mut alphabet, &buffer);
+
+      if let Some(number) = HashIds::unhash(sub_hash, &alphabet) {
+        result.push(number);
+      } else {
+        return None;
+      }
+    }
+
+    if cfg!(debug_assertions) {
+      let check_hash = self._encode(&result);
+      if check_hash != hash {
+        return None;
+      }
+    }
+
+    Some(result)
   }
 
-  fn get_separators(alphabet: String) -> (String, String) {
-    HashIds::get_non_duplicated_string(DEFAULT_SEPARATORS.to_string(), alphabet)
+  fn unhash(input: &[char], alphabet: &[char]) -> Option<u64> {
+    let mut number: u64 = 0;
+    for (i, ch) in input.iter().enumerate() {
+      if let Some(pos) = alphabet.iter().position(|x| x == ch) {
+        number += pos as u64 * (alphabet.len() as u64).pow(input.len() as u32 - i as u32 - 1);
+      } else {
+        return None;
+      }
+    }
+    Some(number)
   }
 
-  fn hashids_shuffle(alphabet: String, salt: String) -> String {
+  fn hash(mut input: u64, alphabet: &[char]) -> Vec<char> {
+    let len = alphabet.len() as u64;
+    let mut result = Vec::new();
+
+    loop {
+      let idx = (input % len) as usize;
+      let ch = alphabet[idx];
+      result.push(ch);
+      input /= len;
+
+      if input == 0 {
+        break;
+      }
+    }
+
+    result.reverse();
+    result
+  }
+
+  pub fn encode(&self, numbers: &[u64]) -> String {
+    if numbers.len() == 0 {
+      panic!("Unable to encode an empty slice of numbers");
+    }
+
+    self._encode(numbers)
+  }
+
+  fn _encode(&self, numbers: &[u64]) -> String {
+    let mut number_hash_int = 0;
+    for (i, &number) in numbers.iter().enumerate() {
+      number_hash_int += number % (i as u64 + 100);
+    }
+
+    let lottery_idx = (number_hash_int % self.alphabet.len() as u64) as usize;
+    let lottery = self.alphabet[lottery_idx];
+    let mut result: Vec<char> = Vec::with_capacity(self.min_hash_length);
+    result.push(lottery);
+
+    let mut alphabet = self.alphabet.clone();
+    let mut buffer = String::with_capacity(alphabet.len());
+    buffer.push(lottery);
+    buffer.push_str(&self.salt);
+    if buffer.len() > alphabet.len() {
+      buffer.truncate(alphabet.len());
+    }
+    let const_buffer_len = buffer.len();
+    for (i, &number) in numbers.iter().enumerate() {
+      buffer.truncate(const_buffer_len);
+      // Don't bother adding anything from alphabet if buffer is long enough already
+      if buffer.len() < alphabet.len() {
+          let extra_needed = alphabet.len() - buffer.len();
+          buffer.extend(alphabet[..extra_needed].iter());
+      }
+      HashIds::shuffle(&mut alphabet, &buffer);
+      let last = HashIds::hash(number, &alphabet);
+
+      result.extend_from_slice(&last);
+
+      if (i + 1) < numbers.len() {
+        let mut sep_idx = (number % (last[0] as u64 + i as u64)) as usize;
+        sep_idx %= self.separators.len();
+        result.push(self.separators[sep_idx]);
+      }
+    }
+
+    if result.len() < self.min_hash_length {
+      let guard_idx = ((number_hash_int + result[0] as u64) % self.guards.len() as u64) as usize;
+      let guard = self.guards[guard_idx];
+      result.insert(0, guard);
+
+      if result.len() < self.min_hash_length {
+        let guard_idx = ((number_hash_int + result[2] as u64) % self.guards.len() as u64) as usize;
+        let guard = self.guards[guard_idx];
+        result.push(guard);
+      }
+    }
+
+    let half_len = alphabet.len() / 2;
+    while result.len() < self.min_hash_length {
+      buffer.clear();
+      buffer.extend(alphabet.iter());
+      HashIds::shuffle(&mut alphabet, &buffer);
+
+      result = alphabet[half_len..].iter().cloned().chain(result.into_iter()).chain(alphabet[..half_len].iter().cloned()).collect();
+
+      let excess = result.len() - self.min_hash_length;
+      if excess > 0 {
+        let start_pos = excess / 2;
+        result.truncate(start_pos + self.min_hash_length);
+        result.drain(..start_pos);
+      }
+    }
+
+    result.into_iter().collect()
+  }
+
+  fn shuffle(alphabet: &mut [char], salt: &str) {
+    let salt = salt.as_bytes();
     if salt.len() <= 0 {
-      return alphabet;
+      return;
     }
 
-    let salt_len = salt.len();
-    let arr = salt.as_bytes();
     let len = alphabet.len();
-    let mut bytes = alphabet.into_bytes();
-    let mut shuffle = &mut bytes[..];
 
     let mut i: usize = len-1;
     let mut v: usize = 0;
     let mut p: usize = 0;
 
     while i > 0 {
-      v %= salt_len;
-      let t = arr[v] as usize;
+      v %= salt.len();
+      let t = salt[v] as usize;
       p += t;
       let j = (t + v + p) % i;
 
-      shuffle.swap(i,j);
+      alphabet.swap(i,j);
 
       i=i-1;
       v=v+1; 
     }
-
-    let mut shuffled_alphabet = String::with_capacity(len);
-    for i in 0..len {
-      shuffled_alphabet.push(shuffle[i] as char);
-    }
-
-    shuffled_alphabet
-  }
-
-  fn get_non_duplicated_string(separators: String, alphabet: String) -> (String, String) {
-    let mut check_separator_map = HashMap::new();
-    let mut check_alphabet_map = HashMap::new();
-
-    let mut modified_separators = String::new();
-    let mut modified_alphabet = String::new();
-    
-    for c in separators.chars() {
-      check_separator_map.insert(c, 1);
-    }
-
-    for c in alphabet.chars() {
-      check_alphabet_map.insert(c, 1);
-    }
-
-    for c in separators.chars() {
-      if check_alphabet_map.contains_key(&c) {
-        modified_separators.push(c);
-      }
-    }
-    
-    for c in alphabet.chars() {
-      if !check_separator_map.contains_key(&c) {
-        modified_alphabet.push(c);
-      }
-    }
-    
-    (modified_separators, modified_alphabet)
-  }
-
-  fn get_unique_alphabet(alphabet: String) -> String {
-    let mut unique_alphabet: String = String::new();
-    let mut check_map = HashMap::new();
-    
-    for c in alphabet.chars() {
-      if !check_map.contains_key(&c) {
-        unique_alphabet.push(c);
-        check_map.insert(c, 1);
-      }
-    }
-
-    unique_alphabet
-  }
-
-  pub fn encode_hex(&self, hex: String) -> String {
-    let regex1 = Regex::new(r"^[0-9a-fA-F]+$").unwrap();
-    if regex1.is_match(&hex.to_string()) == false {
-      return String::new();
-    }
-
-    let mut numbers: Vec<i64> = Vec::new();
-    let regex2 = Regex::new(r"[\w\W]{1,12}").unwrap();
-    for matcher in regex2.find_iter(&hex.to_string()) {
-      let mut num = String::new();
-      num.push('1');
-      num.push_str(&hex[matcher.0..matcher.1]);
-      let v: i64 = i64::from_str_radix(&num.to_string(), 16).unwrap();
-      numbers.push(v);
-    }
-    
-    self.encode(&numbers)
-  }
-
-  pub fn decode_hex(&self, hash: String) -> String {
-    let mut ret = String::new();
-    let numbers = self.decode(hash);
-    for number in numbers.iter() {
-      let r = format!("{:x}", number);
-      ret.push_str(&r[1..]);
-    }
-
-    ret
-  }
-
-  pub fn encode(&self, numbers: &Vec<i64>) -> String {
-    if numbers.len() == 0 {
-      return "".to_string();
-    }
-
-    for number in numbers.iter() {
-      if *number > 9007199254740992 {
-        return "".to_string();
-      }
-    }
-
-    self._encode(numbers)
-  }
-
-  pub fn decode(&self, hash: String) -> Vec<i64> {
-    let ret : Vec<i64> = Vec::new();
-    if hash.len() == 0 {
-      return ret;
-    }
-
-    self._decode(hash)
-  }
-
-  fn _decode(&self, hash: String) -> Vec<i64> {
-    use regex::Regex;
-
-    let mut regexp = String::new();
-    regexp.push('[');
-    regexp.push_str(&self.guards[..]);
-    regexp.push(']');
-
-    let re = Regex::new(&regexp[..]).unwrap();
-    let t_hash = re.replace_all(&hash[..], " ");
-
-    let split1: Vec<&str> = t_hash[..].split_whitespace().collect();
-    let mut i = 0;
-
-    let len = split1.len();
-    if len == 3 || len == 2 {
-      i = 1;
-    }
-    let mut hash_breakdown = split1[i].to_string();
-
-    let lottery = hash_breakdown[0..1].to_string();
-    hash_breakdown = hash_breakdown[1..].to_string();
-
-    let mut regexp2 = String::new();
-    regexp2.push('[');
-    regexp2.push_str(&self.separators[..]);
-    regexp2.push(']');
-
-    let re2 = Regex::new(&regexp2[..]).unwrap();
-    hash_breakdown = re2.replace_all(&hash_breakdown[..], " ");
-
-    let split2: Vec<&str> = hash_breakdown[..].split_whitespace().collect();
-
-    let mut alphabet = self.alphabet.clone();
-
-    let mut ret: Vec<i64> = Vec::new();
-
-    for s in split2 {
-      let sub_hash = s.to_string();
-      let mut buffer = String::new();
-      buffer.push_str(&lottery[..]);
-      buffer.push_str(&self.salt[..]);
-      buffer.push_str(&alphabet.clone()[..]);
-
-      let alpha_len = alphabet.len();
-      alphabet = HashIds::hashids_shuffle(alphabet, buffer[0..alpha_len].to_string());
-      ret.push(HashIds::unhash(sub_hash, alphabet.clone()));
-    }
-
-    let check_hash = self._encode(&ret);
-    if check_hash != hash {
-      return Vec::new();
-    }
-
-    ret
-  }
-
-  fn index_of(input :&[u8], v: u8) -> i64 {
-    let mut i = 0;
-    for s in input.iter() {
-      if *s == v {
-        return i;
-      }
-
-      i += 1;
-    }
-
-    return -1;
-  }
-
-  fn unhash(input: String, alphabet: String) -> i64 {
-    let mut number: i64 = 0;
-    let input_slice = input.as_bytes();
-    let alpha_slice = alphabet.as_bytes();
-    let len = input.len();
-    let alpha_len = alphabet.len() as i64;
-    let mut i: usize = 0;
-    loop {
-      if i >= len {
-        break;
-      }
-
-      let v = input_slice[i] as usize;
-      let pos = HashIds::index_of(alpha_slice, v as u8);
-      let pow_size = (len - i - 1) as u32;
-      number += (pos * alpha_len.pow(pow_size)) as i64;
-      i += 1;
-    }
-
-    number
-  }
-
-  fn hash(input: i64, alphabet: String) -> String {
-    let mut t_in = input;
-    let mut hash = "".to_string();
-    let len = alphabet.len() as i64;
-
-    loop {
-      let idx = (t_in % len) as usize;
-      let mut t = alphabet[idx..idx+1].to_string();
-      t.push_str(&hash[..]);
-      hash = t;
-      t_in /= len;
-
-      if t_in <= 0 {
-        break;
-      }
-    }
-
-    hash
-  }
-
-  fn _encode(&self, numbers: &Vec<i64>) -> String {
-    let mut number_hash_int  = 0;
-    let mut count = 100;
-    for number in numbers.iter() {
-      number_hash_int += *number % count;
-      count += 1;
-    }
-
-    let idx = (number_hash_int % (self.alphabet.len() as i64)) as usize;
-    let ret = self.alphabet[idx..idx+1].to_string();
-    let mut ret_str = ret.clone();
-
-    let mut t_alphabet = self.alphabet.clone();
-    let mut i = 0;
-    let len = self.separators.len() as i64;
-    let last_len = count - 100;
-    for number in numbers.iter() {
-      let mut buffer = ret.clone();
-      buffer.push_str(&self.salt[..]);
-      buffer.push_str(&t_alphabet[..]);
-      t_alphabet = HashIds::hashids_shuffle(t_alphabet.clone(), buffer[0..t_alphabet.len()].to_string());
-      let last = HashIds::hash(*number, t_alphabet.clone());
-
-      ret_str.push_str(&last[..]);
-
-      if (i + 1) < last_len {
-        let mut v = *number % (last.as_bytes()[0] as i64 + i);
-        v = v % len;
-        ret_str.push(self.separators.as_bytes()[v as usize] as char);
-      }
-      i += 1;
-    }
-
-    if ret_str.len() < self.min_hash_length {
-      let guard_idx = (number_hash_int + ret_str.clone().into_bytes()[0] as i64) as usize % self.guards.len();
-      let guard = self.guards[guard_idx..guard_idx+1].to_string();
-      let mut t = guard.clone();
-      t.push_str(&ret_str[..]);
-      ret_str = t;
-
-      if ret_str.len() < self.min_hash_length {
-        let guard_idx = (number_hash_int + ret_str.clone().into_bytes()[2] as i64) as usize % self.guards.len();
-        ret_str.push_str(&self.guards[guard_idx..guard_idx+1]);
-      }
-    }
-
-    let half_len = t_alphabet.len() / 2;
-    while ret_str.len() < self.min_hash_length {
-      t_alphabet = HashIds::hashids_shuffle(t_alphabet.clone(), t_alphabet.clone());
-      let mut t_ret = "".to_string();
-      t_ret.push_str(&t_alphabet[half_len..]);
-      t_ret.push_str(&ret_str[..]);
-      t_ret.push_str(&t_alphabet[0..half_len]);
-      ret_str = t_ret;
-
-      let excess = ret_str.len() as i64 - self.min_hash_length as i64;
-      if excess > 0 {
-        let start_pos = (excess as i64 / 2) as usize;
-        ret_str = ret_str[start_pos..start_pos + self.min_hash_length].to_string();
-      }
-    }
-
-    ret_str
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,13 +233,9 @@ impl HashIds {
 
   pub fn encode(&self, numbers: &[u64]) -> String {
     if numbers.len() == 0 {
-      panic!("Unable to encode an empty slice of numbers");
+      return String::new();
     }
 
-    self._encode(numbers)
-  }
-
-  fn _encode(&self, numbers: &[u64]) -> String {
     let mut number_hash_int: u64 = 0;
     for (i, &number) in numbers.iter().enumerate() {
       number_hash_int = number_hash_int.wrapping_add(number % (i as u64 + 100));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,28 @@
 #![crate_name = "hashids"]
 
+use std::fmt;
+use std::error::Error;
+
 const DEFAULT_ALPHABET: &'static str =  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 const DEFAULT_SEPARATORS: &'static str = "cfhistuCFHISTU";
 const SEPARATOR_DIV: f32 = 3.5;
 const GUARD_DIV: f32 = 12.0;
 const MIN_ALPHABET_LENGTH: usize = 16;
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum HashIdsError { InvalidAlphabetLength }
+
+impl fmt::Display for HashIdsError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.description())
+  }
+}
+
+impl Error for HashIdsError {
+  fn description(&self) -> &str {
+    "Invalid Alphabet Length"
+  }
+}
 
 pub struct HashIds {
   salt: Box<str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,8 @@ impl HashIds {
         let mut buffer = String::new();
         for number in numbers {
           write!(buffer, "{:x}", number).unwrap();
-          result.push_str(&buffer[1..])
+          result.push_str(&buffer[1..]);
+          buffer.clear();
         }
         Some(result)
       },

--- a/tests/javascript_hashids.js
+++ b/tests/javascript_hashids.js
@@ -1,0 +1,25 @@
+var Hashids = require('hashids');
+
+args = process.argv.slice(1);
+var salt = '';
+var minLength = 0;
+var alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+var numbers = [];
+
+for (var i = 0; i < args.length; i++) {
+    var element = args[i];
+    
+    if (element === "-s" || element === "--salt") {
+        salt = args[++i]
+    } else if (element === "-m" || element === "--min-length") {
+        minLength = parseInt(args[++i])
+    } else if (element === "-a" || element === "--alphabet") {
+        alphabet = args[++i]
+    } else {
+        numbers.push(parseInt(element));
+    }
+}
+
+var hashids = new Hashids(salt, minLength, alphabet);
+var encoded = hashids.encode.call(hashids, numbers);
+console.log(encoded);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,7 +4,7 @@ use hashids::HashIds;
 
 #[test]
 fn it_works_1() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -13,16 +13,17 @@ fn it_works_1() {
     }
   };
 
-  let numbers: Vec<i64> = vec![12345];
+  let numbers: Vec<u64> = vec![12345];
   let encode = ids.encode(&numbers);
-  let longs = ids.decode(encode.clone());
+  println!("{}", encode);
+  let longs = ids.decode(&encode).unwrap();
 
   assert_eq!(numbers, longs);
 }
 
 #[test]
 fn it_works_2() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -31,10 +32,10 @@ fn it_works_2() {
     }
   };
 
-  let numbers: Vec<i64> = vec![12345];
+  let numbers: Vec<u64> = vec![12345];
   let encode = ids.encode(&numbers);
 
-  let ids_some2 = HashIds::new_with_salt("this is my pepper".to_string());
+  let ids_some2 = HashIds::new(String::from("this is my pepper"));
   let ids2 = match ids_some2 {
     Ok(v) => { v }
     Err(_) => {
@@ -43,14 +44,12 @@ fn it_works_2() {
     }
   };
 
-  let longs = ids2.decode(encode.clone());
-
-  assert_eq!(longs.len(), 0);
+  assert!(ids2.decode(&encode).is_none());
 }
 
 #[test]
 fn it_works_3() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -59,7 +58,7 @@ fn it_works_3() {
     }
   };
 
-  let numbers: Vec<i64> = vec![683, 94108, 123, 5];
+  let numbers: Vec<u64> = vec![683, 94108, 123, 5];
   let encode = ids.encode(&numbers);
 
   assert_eq!(encode, "aBMswoO2UB3Sj");
@@ -67,7 +66,7 @@ fn it_works_3() {
 
 #[test]
 fn it_works_4() {
-  let ids_some = HashIds::new_with_salt_and_min_length("this is my salt".to_string(), 8);
+  let ids_some = HashIds::with_min_length(String::from("this is my salt"), 8);
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -76,7 +75,7 @@ fn it_works_4() {
     }
   };
 
-  let numbers: Vec<i64> = vec![1];
+  let numbers: Vec<u64> = vec![1];
   let encode = ids.encode(&numbers);
 
   assert_eq!(encode, "gB0NV05e");
@@ -84,7 +83,7 @@ fn it_works_4() {
 
 #[test]
 fn it_works_5() {
-  let ids_some = HashIds::new("this is my salt".to_string(), 0, "0123456789abcdef".to_string());
+  let ids_some = HashIds::with_min_length_and_alphabet(String::from("this is my salt"), 0, "0123456789abcdef");
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -93,7 +92,7 @@ fn it_works_5() {
     }
   };
 
-  let numbers: Vec<i64> = vec![1234567];
+  let numbers: Vec<u64> = vec![1234567];
   let encode = ids.encode(&numbers);
 
   assert_eq!(encode, "b332db5");
@@ -101,7 +100,7 @@ fn it_works_5() {
 
 #[test]
 fn it_works_6() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -110,7 +109,7 @@ fn it_works_6() {
     }
   };
 
-  let numbers: Vec<i64> = vec![5, 5, 5, 5];
+  let numbers: Vec<u64> = vec![5, 5, 5, 5];
   let encode = ids.encode(&numbers);
 
   assert_eq!(encode, "1Wc8cwcE");
@@ -118,7 +117,7 @@ fn it_works_6() {
 
 #[test]
 fn it_works_7() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -127,7 +126,7 @@ fn it_works_7() {
     }
   };
 
-  let numbers: Vec<i64> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  let numbers: Vec<u64> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   let encode = ids.encode(&numbers);
 
   assert_eq!(encode, "kRHnurhptKcjIDTWC3sx");
@@ -135,7 +134,7 @@ fn it_works_7() {
 
 #[test]
 fn it_works_8() {
-  let ids_some = HashIds::new_with_salt("this is my salt".to_string());
+  let ids_some = HashIds::new(String::from("this is my salt"));
   let ids = match ids_some {
     Ok(v) => { v }
     Err(_) => {
@@ -144,15 +143,15 @@ fn it_works_8() {
     }
   };
 
-  let numbers_1: Vec<i64> = vec![1];
+  let numbers_1: Vec<u64> = vec![1];
   let encode_1 = ids.encode(&numbers_1);
-  let numbers_2: Vec<i64> = vec![2];
+  let numbers_2: Vec<u64> = vec![2];
   let encode_2 = ids.encode(&numbers_2);
-  let numbers_3: Vec<i64> = vec![3];
+  let numbers_3: Vec<u64> = vec![3];
   let encode_3 = ids.encode(&numbers_3);
-  let numbers_4: Vec<i64> = vec![4];
+  let numbers_4: Vec<u64> = vec![4];
   let encode_4 = ids.encode(&numbers_4);
-  let numbers_5: Vec<i64> = vec![5];
+  let numbers_5: Vec<u64> = vec![5];
   let encode_5 = ids.encode(&numbers_5);
 
   assert_eq!(encode_1, "NV");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -84,9 +84,6 @@ fn bad() {
 
 quickcheck! {
   fn equals_javascript(salt: Vec<u8>, alphabet: Vec<u8>, min_len: usize, nums: Vec<u64>) -> TestResult {
-    if nums.is_empty() {
-      return TestResult::discard();
-    }
     // make alphabet ascii
     let mut alphabet = alphabet;
     for ch in alphabet.iter_mut() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -4,14 +4,7 @@ use hashids::HashIds;
 
 #[test]
 fn it_works_1() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers: Vec<u64> = vec![12345];
   let encode = ids.encode(&numbers);
@@ -23,40 +16,19 @@ fn it_works_1() {
 
 #[test]
 fn it_works_2() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers: Vec<u64> = vec![12345];
   let encode = ids.encode(&numbers);
 
-  let ids_some2 = HashIds::new(String::from("this is my pepper"));
-  let ids2 = match ids_some2 {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids2 = HashIds::new(String::from("this is my pepper")).unwrap();
 
   assert!(ids2.decode(&encode).is_none());
 }
 
 #[test]
 fn it_works_3() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers: Vec<u64> = vec![683, 94108, 123, 5];
   let encode = ids.encode(&numbers);
@@ -66,14 +38,7 @@ fn it_works_3() {
 
 #[test]
 fn it_works_4() {
-  let ids_some = HashIds::with_min_length(String::from("this is my salt"), 8);
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::with_min_length(String::from("this is my salt"), 8).unwrap();
 
   let numbers: Vec<u64> = vec![1];
   let encode = ids.encode(&numbers);
@@ -83,14 +48,7 @@ fn it_works_4() {
 
 #[test]
 fn it_works_5() {
-  let ids_some = HashIds::with_min_length_and_alphabet(String::from("this is my salt"), 0, "0123456789abcdef");
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::with_min_length_and_alphabet(String::from("this is my salt"), 0, "0123456789abcdef").unwrap();
 
   let numbers: Vec<u64> = vec![1234567];
   let encode = ids.encode(&numbers);
@@ -100,14 +58,7 @@ fn it_works_5() {
 
 #[test]
 fn it_works_6() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers: Vec<u64> = vec![5, 5, 5, 5];
   let encode = ids.encode(&numbers);
@@ -117,14 +68,7 @@ fn it_works_6() {
 
 #[test]
 fn it_works_7() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers: Vec<u64> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   let encode = ids.encode(&numbers);
@@ -134,14 +78,7 @@ fn it_works_7() {
 
 #[test]
 fn it_works_8() {
-  let ids_some = HashIds::new(String::from("this is my salt"));
-  let ids = match ids_some {
-    Ok(v) => { v }
-    Err(_) => {
-      println!("error");
-      return;
-    }
-  };
+  let ids = HashIds::new(String::from("this is my salt")).unwrap();
 
   let numbers_1: Vec<u64> = vec![1];
   let encode_1 = ids.encode(&numbers_1);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -70,16 +70,15 @@ fn default_equal_explicit() {
 
 #[test]
 fn bad() {
-  // let alphabet = [1, 72, 2, 4, 5, 6, 7, 8, 70, 9, 10, 11, 12, 13, 14, 3];
-  // \x01\x48\x02\x04\x05\x06\x07\x08\x46\x09\x0A\x0B\x0C\x0D\x0E\x03
-  let alphabet = [1, 72, 2, 4, 5, 6, 7, 8, 70, 9, 10, 11, 12, 13, 14, 3];
-  let alphabet = str::from_utf8(&alphabet).unwrap();
   let ids = HashIdsBuilder::new()
-    .alphabet(alphabet)
+    .min_length(3)
     .build()
     .unwrap();
-  let data = [0, 0];
-  assert_eq!(ids.encode(&data), run_javascript("", alphabet, 0, &data).unwrap());
+  let data = [0];
+  let encoded = ids.encode(&data);
+  assert_eq!(encoded, run_javascript("", "", 3, &data).unwrap());
+  let decoded = ids.decode(&encoded).unwrap();
+  assert_eq!(decoded, data);
 }
 
 
@@ -116,7 +115,10 @@ quickcheck! {
 
     match ids {
       Ok(ids) => {
-        assert_eq!(ids.encode(&nums), js_result.unwrap());
+        let encoded = ids.encode(&nums);
+        assert_eq!(encoded, js_result.unwrap());
+        let decoded = ids.decode(&encoded).unwrap();
+        assert_eq!(decoded, nums);
       }
       Err(_) => {
         assert!(js_result.is_err(), "{:?}", js_result);
@@ -127,90 +129,3 @@ quickcheck! {
     TestResult::passed()
   }
 }
-
-/*
-#[test]
-fn it_works_2() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
-
-  let numbers: Vec<u64> = vec![12345];
-  let encode = ids.encode(&numbers);
-
-  let ids2 = HashIds::new(String::from("this is my pepper")).unwrap();
-
-  assert!(ids2.decode(&encode).is_none());
-}
-
-#[test]
-fn it_works_3() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
-
-  let numbers: Vec<u64> = vec![683, 94108, 123, 5];
-  let encode = ids.encode(&numbers);
-
-  assert_eq!(encode, "aBMswoO2UB3Sj");
-}
-
-#[test]
-fn it_works_4() {
-  let ids = HashIds::with_min_length(String::from("this is my salt"), 8).unwrap();
-
-  let numbers: Vec<u64> = vec![1];
-  let encode = ids.encode(&numbers);
-
-  assert_eq!(encode, "gB0NV05e");
-}
-
-#[test]
-fn it_works_5() {
-  let ids = HashIds::with_min_length_and_alphabet(String::from("this is my salt"), 0, "0123456789abcdef").unwrap();
-
-  let numbers: Vec<u64> = vec![1234567];
-  let encode = ids.encode(&numbers);
-
-  assert_eq!(encode, "b332db5");
-}
-
-#[test]
-fn it_works_6() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
-
-  let numbers: Vec<u64> = vec![5, 5, 5, 5];
-  let encode = ids.encode(&numbers);
-
-  assert_eq!(encode, "1Wc8cwcE");
-}
-
-#[test]
-fn it_works_7() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
-
-  let numbers: Vec<u64> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  let encode = ids.encode(&numbers);
-
-  assert_eq!(encode, "kRHnurhptKcjIDTWC3sx");
-}
-
-#[test]
-fn it_works_8() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
-
-  let numbers_1: Vec<u64> = vec![1];
-  let encode_1 = ids.encode(&numbers_1);
-  let numbers_2: Vec<u64> = vec![2];
-  let encode_2 = ids.encode(&numbers_2);
-  let numbers_3: Vec<u64> = vec![3];
-  let encode_3 = ids.encode(&numbers_3);
-  let numbers_4: Vec<u64> = vec![4];
-  let encode_4 = ids.encode(&numbers_4);
-  let numbers_5: Vec<u64> = vec![5];
-  let encode_5 = ids.encode(&numbers_5);
-
-  assert_eq!(encode_1, "NV");
-  assert_eq!(encode_2, "6m");
-  assert_eq!(encode_3, "yD");
-  assert_eq!(encode_4, "2l");
-  assert_eq!(encode_5, "rD");
-}
-
-*/

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -69,14 +69,13 @@ fn default_equal_explicit() {
 
 #[test]
 fn bad() {
-  let alphabet = "\u{10}\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\t\n\u{b}\u{c}\r\u{e}\u{80}";
+  let alphabet = "\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\n\u{f}\r\u{11}\u{0}\t\u{b}\u{c}";
   let ids = HashIdsBuilder::new()
     .alphabet(alphabet)
     .build()
     .unwrap();
-  let data = [55];
+  let data = [13, 6, 47, 11, 25];
   let encoded = ids.encode(&data);
-  assert_eq!(encoded, run_javascript("", alphabet, 0, &data).unwrap());
   let decoded = ids.decode(&encoded).unwrap();
   assert_eq!(decoded, data);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,16 @@
 extern crate hashids;
+#[macro_use]
+extern crate quickcheck;
 
-use hashids::HashIds;
+use quickcheck::TestResult;
+
+use hashids::{HashIds, HashIdsBuilder};
+use std::str;
+use std::process::Command;
 
 #[test]
 fn it_works_1() {
-  let ids = HashIds::new(String::from("this is my salt")).unwrap();
+  let ids = HashIds::with_salt(String::from("this is my salt"));
 
   let numbers: Vec<u64> = vec![12345];
   let encode = ids.encode(&numbers);
@@ -14,6 +20,115 @@ fn it_works_1() {
   assert_eq!(numbers, longs);
 }
 
+fn run_javascript(salt: &str, alphabet: &str, min_len: usize, nums: &[u64]) -> Result<String, String> {
+  let mut command = Command::new("node");
+
+  command
+    .arg("-e")
+    .arg(include_str!("javascript_hashids.js"))
+    .arg("--")
+    .args(nums.iter().map(|i| i.to_string()));
+
+  command
+    .arg("-m")
+    .arg(&min_len.to_string());
+  if ! salt.is_empty() {
+    command
+      .arg("-s")
+      .arg(salt);
+  }
+  if ! alphabet.is_empty() {
+    command
+      .arg("-a")
+      .arg(alphabet);
+  }
+
+  let mut output = command
+    .output()
+    .unwrap();
+  output.stdout.pop();
+  output.stderr.pop();
+  if output.status.success() {
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+  } else {
+    Err(String::from_utf8_lossy(&output.stderr).into_owned())
+  }
+}
+
+#[test]
+fn default_equal_explicit() {
+  let ids_def = HashIds::new();
+  let ids_exp = HashIdsBuilder::new()
+    .salt(String::new())
+    .alphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+    .build()
+    .unwrap();
+  let data = [1, 2, 3, 4, 999];
+  assert_eq!(ids_def.encode(&data), run_javascript("", "", 0, &data).unwrap());
+  assert_eq!(ids_def.encode(&data), ids_exp.encode(&data));
+}
+
+#[test]
+fn bad() {
+  // let alphabet = [1, 72, 2, 4, 5, 6, 7, 8, 70, 9, 10, 11, 12, 13, 14, 3];
+  // \x01\x48\x02\x04\x05\x06\x07\x08\x46\x09\x0A\x0B\x0C\x0D\x0E\x03
+  let alphabet = [1, 72, 2, 4, 5, 6, 7, 8, 70, 9, 10, 11, 12, 13, 14, 3];
+  let alphabet = str::from_utf8(&alphabet).unwrap();
+  let ids = HashIdsBuilder::new()
+    .alphabet(alphabet)
+    .build()
+    .unwrap();
+  let data = [0, 0];
+  assert_eq!(ids.encode(&data), run_javascript("", alphabet, 0, &data).unwrap());
+}
+
+
+quickcheck! {
+  fn equals_javascript(salt: Vec<u8>, alphabet: Vec<u8>, min_len: usize, nums: Vec<u64>) -> TestResult {
+    if nums.is_empty() {
+      return TestResult::discard();
+    }
+    // make alphabet ascii
+    let mut alphabet = alphabet;
+    for ch in alphabet.iter_mut() {
+      *ch = *ch & 0x7F;
+    }
+    let alphabet = String::from_utf8(alphabet).unwrap();
+    // make salt ascii
+    let mut salt = salt;
+    for ch in salt.iter_mut() {
+      *ch = *ch & 0x7F;
+    }
+    let salt = String::from_utf8(salt).unwrap();
+    if salt.contains('\0') || alphabet.contains('\0') {
+      return TestResult::discard();
+    }
+    let js_result = run_javascript(&salt, &alphabet, min_len, &nums);
+    let mut builder = HashIdsBuilder::new().min_length(min_len);
+    if ! salt.is_empty() {
+      builder = builder.salt(salt);
+    }
+    if ! alphabet.is_empty() {
+      builder = builder.alphabet(&alphabet)
+    }
+
+    let ids = builder.build();
+
+    match ids {
+      Ok(ids) => {
+        assert_eq!(ids.encode(&nums), js_result.unwrap());
+      }
+      Err(_) => {
+        assert!(js_result.is_err(), "{:?}", js_result);
+        return TestResult::discard();
+      }
+    }
+
+    TestResult::passed()
+  }
+}
+
+/*
 #[test]
 fn it_works_2() {
   let ids = HashIds::new(String::from("this is my salt")).unwrap();
@@ -97,3 +212,5 @@ fn it_works_8() {
   assert_eq!(encode_4, "2l");
   assert_eq!(encode_5, "rD");
 }
+
+*/


### PR DESCRIPTION
Try to remove as many extra allocations as possible. This also removes the dependency on the regex crate.

It's worth noting that this has some fairly breaking changes, and would therefore not be eligible to stay in the 1.0 stream.
